### PR TITLE
Add postgresql as DB in django settings.py

### DIFF
--- a/backend/backend/core/settings.py
+++ b/backend/backend/core/settings.py
@@ -75,8 +75,12 @@ WSGI_APPLICATION = 'core.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'quibble_db',
+        'USER': 'myuser',
+        'PASSWORD': 'quibble_pass',
+		'HOST': 'localhost',
+		'PORT': '5432',
     }
 }
 


### PR DESCRIPTION
This pull request updates the DATABASES setting in the settings.py file to configure PostgreSQL as the database backend for the Django project. The changes include:

    Replacing the default SQLite configuration with PostgreSQL (django.db.backends.postgresql).
    Specifying the database name, user, password, host, and port in the settings.
   

Changes made:

    Updated DATABASES in settings.py to use PostgreSQL.