### PR TITLE
fix: refresh/re-use profiles for credentials

### DIFF
--- a/frontend/src/lib/modals/modal-auth/forms/profile-create.svelte
+++ b/frontend/src/lib/modals/modal-auth/forms/profile-create.svelte
@@ -44,7 +44,8 @@
         // append to existing profiles on forms_state
         update_forms_state('profile_select', {
           profiles: [
-            ...(forms_state.profile_select as { profiles: object[] }).profiles,
+            // @ts-expect-error: no typing needs for this part
+            ...forms_state.profile_select.profiles,
             result.data
           ]
         });

--- a/frontend/src/lib/modals/modal-auth/forms/profile-select.svelte
+++ b/frontend/src/lib/modals/modal-auth/forms/profile-select.svelte
@@ -41,11 +41,17 @@
   };
 
   onMount(async () => {
-    // check if forms_state has profiles
-    // so avoid a query
-    if ((forms_state.profile_select as { profiles: Profile[] }).profiles) {
+    if (
+      (forms_state.join as { token: string }).token ===
+      (forms_state.profile_select as { token: string }).token
+    ) {
+      console.log('same token detected!');
+      console.log('re-using...');
       profiles = (forms_state.profile_select as { profiles: Profile[] }).profiles;
     } else {
+      console.log('new user');
+      console.log('fetching...');
+      // so avoid a query
       pending = true;
       status_text = 'Fetching profiles...';
 
@@ -58,7 +64,10 @@
       if (response.ok && data) {
         profiles = data;
         // add to forms_state
-        update_forms_state('profile_select', { profiles });
+        update_forms_state('profile_select', {
+          token: (forms_state.join as { token: string }).token,
+          profiles
+        });
       } else if (error) {
         console.log(error);
       }


### PR DESCRIPTION
in `profile_select` form, fetch profiles if its a new user request or re-use profiles which has been saved to `forms_state`.
thus reduce api queries to backend for profiles.

fixes #150 