### PR TITLE
refactor: create superforms on client

### DIFF
--- a/frontend/src/lib/modals/modal-auth/forms/join.svelte
+++ b/frontend/src/lib/modals/modal-auth/forms/join.svelte
@@ -13,6 +13,7 @@
 
   let { update_forms_state, goto_form, forms_state }: FormProps<typeof forms> = $props();
 
+  // for persisent data even after navigating b/w forms
   const initial_data = {
     email: (forms_state.join as { email?: string }).email,
     password: (forms_state.join as { password?: string }).password
@@ -20,6 +21,7 @@
 
   const { form, enhance, errors, message, delayed } = superForm(
     defaults(initial_data, zod(AuthSchema)),
+    // form options
     {
       resetForm: false,
       validators: zod(AuthSchema),
@@ -29,7 +31,10 @@
         if (auth_type === 'login') {
           // save token on forms_state
           update_forms_state('join', {
-            token: (result as FormResult<{ data?: { token?: string } }>).data?.token
+            token: (result as FormResult<{ data?: { token?: string } }>).data?.token,
+            // for persisent form datas
+            email: $form.email,
+            password: $form.password
           });
           // next form
           goto_form('profile_select');

--- a/frontend/src/lib/modals/modal-auth/forms/profile-create.svelte
+++ b/frontend/src/lib/modals/modal-auth/forms/profile-create.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
-  import { page } from '$app/state';
   import QuibbleTextLogo from '$lib/components/icons/logos/quibble-text.svelte';
   import QuibbleLogo from '$lib/components/icons/logos/quibble.svelte';
   import { cn } from '$lib/functions/classnames';
   import { ProfileNewSchema } from '$lib/schemas/auth';
   import type { FormProps } from '../../types';
   import forms from '../forms';
-  import { superForm, type FormResult } from 'sveltekit-superforms';
+  import { defaults, superForm, type FormResult } from 'sveltekit-superforms';
   import { zod } from 'sveltekit-superforms/adapters';
 
   let { forms_state, update_forms_state, goto_form }: FormProps<typeof forms> = $props();
 
-  const { form, enhance, errors, message, delayed } = superForm(page.data.form_auth_profile_new, {
+  const { form, enhance, errors, message, delayed } = superForm(defaults(zod(ProfileNewSchema)), {
     resetForm: false,
     validators: zod(ProfileNewSchema),
     onResult({ result }) {

--- a/frontend/src/routes/+layout.server.ts
+++ b/frontend/src/routes/+layout.server.ts
@@ -1,16 +1,7 @@
-import { AuthSchema, ProfileNewSchema } from '$lib/schemas/auth';
 import type { LayoutServerLoad } from './$types';
-import { superValidate } from 'sveltekit-superforms';
-import { zod } from 'sveltekit-superforms/adapters';
 
 export const load: LayoutServerLoad = async ({ locals }) => {
-  const form_auth_join = await superValidate(zod(AuthSchema));
-  const form_auth_profile_new = await superValidate(zod(ProfileNewSchema));
-
   return {
-    profile: locals.profile,
-    // superforms
-    form_auth_join,
-    form_auth_profile_new
+    profile: locals.profile
   };
 };


### PR DESCRIPTION
instead of creating forms instance from svelte/kit server, create them on client with defaults and initial data for persistent form datas. this is only because, we don't need to keep a auth related forms on server even after authentication.