### PR TITLE
fix: ratio attribute error in comment viewset

### DIFF
--- a/backend/apps/api/viewsets/comment/__init__.py
+++ b/backend/apps/api/viewsets/comment/__init__.py
@@ -5,7 +5,7 @@ from ...serializers.comment import CommentDetailSerializer
 
 
 class CommentViewSet(UpdateRetrieveDestroyViewSet):
-    queryset = Comment.objects.all()
+    queryset = Comment.objects.with_annotated_ratio()
     serializer_class = CommentDetailSerializer
 
     def perform_destroy(self, instance):


### PR DESCRIPTION
## Description

This PR fix an attribute error in `CommentViewSet` API.
```
AttributeError: Got AttributeError when attempting to get a value for field `ratio` on serializer `CommentDetailSerializer`.
The serializer field might be named incorrectly and not match any attribute or key on the `Comment` instance.
Original exception text was: 'Comment' object has no attribute 'ratio'.
```

Fixes # (nil)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
