### PR TITLE
fix: limit sidebar state(s) length

### DIFF
--- a/frontend/src/lib/components/sidebar.svelte
+++ b/frontend/src/lib/components/sidebar.svelte
@@ -5,6 +5,7 @@
   import { createAuthStore } from '$lib/stores/auth.svelte';
   import { createModalsStore } from '$lib/stores/modals.svelte';
   import { createSidebarStore } from '$lib/stores/sidebar.svelte';
+  import { fly } from 'svelte/transition';
 
   const sidebarStore = createSidebarStore(),
     modalsStore = createModalsStore(),
@@ -47,13 +48,20 @@
       class="collapse-title flex h-max min-h-max items-center justify-between p-0 text-sm font-medium text-base-content/75 peer-checked:[&>coreicons-shape-chevron]:rotate-180"
     >
       Recent
-      <coreicons-shape-chevron class="size-4 transition-transform" variant="down"
-      ></coreicons-shape-chevron>
+      <div class="flex items-center gap-2">
+        <button
+          onclick={sidebarStore.clear_recents}
+          class="z-10 rounded-full p-1 px-2 text-xs transition-colors hover:bg-primary/40 hover:text-white"
+          >Clear</button
+        >
+        <coreicons-shape-chevron class="size-4 transition-transform" variant="down"
+        ></coreicons-shape-chevron>
+      </div>
     </div>
     {#if sidebarStore.state.recent}
       <div class="collapse-content flex flex-col gap-2 !p-0">
         {#each sidebarStore.state.recent as community}
-          <div class="flex items-center gap-2">
+          <div class="flex items-center gap-2" transition:fly={{ y: -15 }}>
             <a href="/q/{community.name}" class="flex">
               <Avatar src={community.avatar} />
             </a>
@@ -73,6 +81,7 @@
       <span class="text-sm">Just in—take a peek.</span>
     {/if}
   </div>
+
   <div class="collapse gap-2 overflow-visible rounded-none">
     <input type="checkbox" checked={true} class="peer h-max min-h-full w-full" />
     <div
@@ -86,10 +95,10 @@
       <div class="collapse-content flex flex-col gap-2 !p-0">
         {#each sidebarStore.state.your as community}
           <div class="flex items-center gap-2">
-            <a href="q/{community.name}" class="flex">
+            <a href="/q/{community.name}" class="flex">
               <Avatar src={community.avatar} />
             </a>
-            <a href="q/{community.name}" class="text-sm font-medium">q/{community.name}</a>
+            <a href="/q/{community.name}" class="text-sm font-medium">q/{community.name}</a>
             <button
               onclick={() => sidebarStore.toggle_star('your', community.name)}
               class="ml-auto"

--- a/frontend/src/lib/components/sidebar.svelte
+++ b/frontend/src/lib/components/sidebar.svelte
@@ -48,8 +48,10 @@
     >
       Recent
       <div class="flex items-center gap-2">
-        <button class="btn btn-ghost btn-xs z-10" onclick={() => sidebarStore.clear('recent')}
-          >Clear</button
+        <button
+          class="btn btn-ghost btn-xs z-10"
+          disabled={sidebarStore.state.recent?.length === 0}
+          onclick={() => sidebarStore.clear('recent')}>Clear</button
         >
         <coreicons-shape-chevron class="size-4 transition-transform" variant="down"
         ></coreicons-shape-chevron>
@@ -86,8 +88,10 @@
     >
       Your Communities
       <div class="flex items-center gap-2">
-        <button class="btn btn-ghost btn-xs z-10" onclick={() => sidebarStore.clear('your')}
-          >Clear</button
+        <button
+          class="btn btn-ghost btn-xs z-10"
+          disabled={sidebarStore.state.your?.length === 0}
+          onclick={() => sidebarStore.clear('your')}>Clear</button
         >
         <coreicons-shape-chevron class="size-4 transition-transform" variant="down"
         ></coreicons-shape-chevron>

--- a/frontend/src/lib/components/sidebar.svelte
+++ b/frontend/src/lib/components/sidebar.svelte
@@ -5,7 +5,6 @@
   import { createAuthStore } from '$lib/stores/auth.svelte';
   import { createModalsStore } from '$lib/stores/modals.svelte';
   import { createSidebarStore } from '$lib/stores/sidebar.svelte';
-  import { fly } from 'svelte/transition';
 
   const sidebarStore = createSidebarStore(),
     modalsStore = createModalsStore(),
@@ -45,23 +44,21 @@
   <div class="collapse gap-2 overflow-visible rounded-none">
     <input type="checkbox" checked={true} class="peer h-max min-h-full w-full" />
     <div
-      class="collapse-title flex h-max min-h-max items-center justify-between p-0 text-sm font-medium text-base-content/75 peer-checked:[&>coreicons-shape-chevron]:rotate-180"
+      class="collapse-title flex h-max min-h-max items-center justify-between p-0 text-sm font-medium text-base-content/75 peer-checked:[&>div>coreicons-shape-chevron]:rotate-180"
     >
       Recent
       <div class="flex items-center gap-2">
-        <button
-          onclick={sidebarStore.clear_recents}
-          class="z-10 rounded-full p-1 px-2 text-xs transition-colors hover:bg-primary/40 hover:text-white"
+        <button class="btn btn-ghost btn-xs z-10" onclick={() => sidebarStore.clear('recent')}
           >Clear</button
         >
         <coreicons-shape-chevron class="size-4 transition-transform" variant="down"
         ></coreicons-shape-chevron>
       </div>
     </div>
-    {#if sidebarStore.state.recent}
+    {#if sidebarStore.state.recent?.length}
       <div class="collapse-content flex flex-col gap-2 !p-0">
         {#each sidebarStore.state.recent as community}
-          <div class="flex items-center gap-2" transition:fly={{ y: -15 }}>
+          <div class="flex items-center gap-2">
             <a href="/q/{community.name}" class="flex">
               <Avatar src={community.avatar} />
             </a>
@@ -85,13 +82,18 @@
   <div class="collapse gap-2 overflow-visible rounded-none">
     <input type="checkbox" checked={true} class="peer h-max min-h-full w-full" />
     <div
-      class="collapse-title flex h-max min-h-max items-center justify-between p-0 text-sm font-medium text-base-content/75 peer-checked:[&>coreicons-shape-chevron]:rotate-180"
+      class="collapse-title flex h-max min-h-max items-center justify-between p-0 text-sm font-medium text-base-content/75 peer-checked:[&>div>coreicons-shape-chevron]:rotate-180"
     >
       Your Communities
-      <coreicons-shape-chevron class="size-4 transition-transform" variant="down"
-      ></coreicons-shape-chevron>
+      <div class="flex items-center gap-2">
+        <button class="btn btn-ghost btn-xs z-10" onclick={() => sidebarStore.clear('your')}
+          >Clear</button
+        >
+        <coreicons-shape-chevron class="size-4 transition-transform" variant="down"
+        ></coreicons-shape-chevron>
+      </div>
     </div>
-    {#if sidebarStore.state.your}
+    {#if sidebarStore.state.your?.length}
       <div class="collapse-content flex flex-col gap-2 !p-0">
         {#each sidebarStore.state.your as community}
           <div class="flex items-center gap-2">

--- a/frontend/src/lib/constants/limits.ts
+++ b/frontend/src/lib/constants/limits.ts
@@ -1,1 +1,2 @@
 export const PROFILE_CREATE_LIMIT = 3;
+export const SIDEBAR_MAX_ITEMS_LIMIT = 10;

--- a/frontend/src/routes/(app)/q/[name]/+page.svelte
+++ b/frontend/src/routes/(app)/q/[name]/+page.svelte
@@ -29,6 +29,7 @@
     });
   }
 
+  // It only works on full page reloading. wont work with Client Side navigation.
   onMount(() => {
     add_to_sidebar_store('recent');
     if (is_joined) add_to_sidebar_store('your');

--- a/frontend/src/routes/(app)/q/[name]/+page.svelte
+++ b/frontend/src/routes/(app)/q/[name]/+page.svelte
@@ -29,7 +29,6 @@
     });
   }
 
-  // It only works on full page reloading. wont work with Client Side navigation.
   onMount(() => {
     add_to_sidebar_store('recent');
     if (is_joined) add_to_sidebar_store('your');


### PR DESCRIPTION
<!-- IMPORTANT: Please make sure you've pre-commit installed and have run it on commit. -->
<!-- Also follow contribution guidelines: https://github.com/quibble-dev/Quibble/blob/main/CONTRIBUTING.md -->

## Description

- Sidebar items shows maximum 10 items.
- Made recent section sort by visited order.

Fixes #183 
[[Bug]: limit sidebar state(s) length](https://github.com/quibble-dev/Quibble/issues/183)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
