### PR TITLE
fix: ensure text remains visible during webfont load

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -8,6 +8,7 @@
     src: url('/assets/fonts/roboto/Roboto-Thin.ttf') format('truetype');
     font-weight: 100;
     font-style: normal;
+    font-display: swap;
   }
 
   @font-face {
@@ -15,6 +16,7 @@
     src: url('/assets/fonts/roboto/Roboto-Light.ttf') format('truetype');
     font-weight: 300;
     font-style: normal;
+    font-display: swap;
   }
 
   @font-face {
@@ -22,6 +24,7 @@
     src: url('/assets/fonts/roboto/Roboto-Regular.ttf') format('truetype');
     font-weight: 400;
     font-style: normal;
+    font-display: swap;
   }
 
   @font-face {
@@ -29,6 +32,7 @@
     src: url('/assets/fonts/roboto/Roboto-Medium.ttf') format('truetype');
     font-weight: 500;
     font-style: normal;
+    font-display: swap;
   }
 
   @font-face {
@@ -36,6 +40,7 @@
     src: url('/assets/fonts/roboto/Roboto-Bold.ttf') format('truetype');
     font-weight: 700;
     font-style: normal;
+    font-display: swap;
   }
 
   @font-face {
@@ -43,6 +48,7 @@
     src: url('/assets/fonts/roboto/Roboto-Black.ttf') format('truetype');
     font-weight: 900;
     font-style: normal;
+    font-display: swap;
   }
 }
 


### PR DESCRIPTION
<!-- IMPORTANT: Please make sure you've pre-commit installed and have run it on commit. -->
<!-- Also follow contribution guidelines: https://github.com/quibble-dev/Quibble/blob/main/CONTRIBUTING.md -->

## Description

Add `font-display: swap` to locally shipped fonts avoid flash of unloaded fonts.
ensures it remains visible.

Fixes #196 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
