### PR TITLE
fix: handle user idle state case

### DIFF
--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -1,6 +1,6 @@
 import api from '$lib/api';
+import { handle_refresh_access_token, handle_verify_access_token } from '$lib/server/utils/auth';
 import { set_cookies_from_header } from '$lib/server/utils/cookie';
-import type { Nullable } from '$lib/types/shared';
 import type { Handle } from '@sveltejs/kit';
 
 const auth_routes = ['/login', '/register', '/password'];
@@ -64,40 +64,3 @@ export const handle: Handle = async ({ event, resolve }) => {
 
   return await resolve(event);
 };
-
-/**
- * A utility function to check if access token if valid or not.
- * @param access_token - Access token to check.
- * @returns Promise<boolean>
- */
-async function handle_verify_access_token(access_token: string): Promise<boolean> {
-  const { response } = await api.POST('/auth/token/verify/', {
-    body: { token: access_token }
-  });
-
-  return response.ok;
-}
-
-/**
- * A utility function to make API requests.
- * @param refresh_token - Refresh token to send along with request.
- * @param cookie_header - Cookies to send
- * @returns Promise<Nullable<Response>>
- */
-async function handle_refresh_access_token(
-  refresh_token: string,
-  cookie_header: Nullable<string>
-): Promise<Nullable<Response>> {
-  const { response, error } = await api.POST('/auth/token/refresh/', {
-    headers: { Cookie: cookie_header },
-    // @ts-expect-error: only refresh token required
-    body: { refresh: refresh_token }
-  });
-
-  if (response.ok) {
-    return response;
-  } else {
-    console.log('refresh_access_token failed with err: ', error);
-    return null;
-  }
-}

--- a/frontend/src/lib/constants/auth.ts
+++ b/frontend/src/lib/constants/auth.ts
@@ -1,0 +1,1 @@
+export const TOKEN_REFRESH_INTERVAL = 14.5 * 60 * 1000; // 14.5 mins

--- a/frontend/src/lib/server/utils/auth.ts
+++ b/frontend/src/lib/server/utils/auth.ts
@@ -1,0 +1,39 @@
+import api from '$lib/api';
+import type { Nullable } from '$lib/types/shared';
+
+/**
+ * A utility function to check if access token if valid or not.
+ * @param access_token - Access token to check.
+ * @returns Promise<boolean>
+ */
+export async function handle_verify_access_token(access_token: string): Promise<boolean> {
+  const { response } = await api.POST('/auth/token/verify/', {
+    body: { token: access_token }
+  });
+
+  return response.ok;
+}
+
+/**
+ * A utility function to make API requests.
+ * @param refresh_token - Refresh token to send along with request.
+ * @param cookie_header - Cookies to send
+ * @returns Promise<Nullable<Response>>
+ */
+export async function handle_refresh_access_token(
+  refresh_token: string,
+  cookie_header: Nullable<string>
+): Promise<Nullable<Response>> {
+  const { response, error } = await api.POST('/auth/token/refresh/', {
+    headers: { Cookie: cookie_header },
+    // @ts-expect-error: only refresh token required
+    body: { refresh: refresh_token }
+  });
+
+  if (response.ok) {
+    return response;
+  } else {
+    console.log('refresh_access_token failed with err: ', error);
+    return null;
+  }
+}

--- a/frontend/src/routes/(api)/api/v1/auth/token/refresh/+server.ts
+++ b/frontend/src/routes/(api)/api/v1/auth/token/refresh/+server.ts
@@ -1,0 +1,20 @@
+import { handle_refresh_access_token } from '$lib/server/utils/auth';
+import { set_cookies_from_header } from '$lib/server/utils/cookie';
+import { json, type RequestHandler } from '@sveltejs/kit';
+
+export const POST: RequestHandler = async ({ cookies, request }) => {
+  const refresh_token = cookies.get('jwt-refresh');
+  if (!refresh_token) return json({ success: false }, { status: 401 });
+
+  try {
+    const res = await handle_refresh_access_token(refresh_token, request.headers.get('Cookie'));
+    if (res && res.headers.getSetCookie()) {
+      set_cookies_from_header(res.headers.getSetCookie(), cookies);
+    }
+
+    return json({ success: true });
+  } catch (err) {
+    console.error('token refresh failed: ', err);
+    return json({ success: false }, { status: 401 });
+  }
+};

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { afterNavigate, beforeNavigate } from '$app/navigation';
   import Toaster from '$lib/components/ui/toast';
+  import { TOKEN_REFRESH_INTERVAL } from '$lib/constants/auth';
   import Modals from '$lib/modals/index.svelte';
   import { createAuthStore } from '$lib/stores/auth.svelte';
   import '../styles/app.css';
@@ -36,6 +37,19 @@
 
   onMount(() => {
     defineCustomElements();
+    // send token refresh request interval
+    if (!authStore.state.is_authenticated) return;
+
+    const interval = setInterval(async () => {
+      const res = await fetch('/api/v1/auth/token/refresh', { method: 'POST' });
+      if (!res.ok) {
+        // refresh token expired or invalid
+        window.location.href = '/login?session-expired=true';
+        clearInterval(interval);
+      }
+    }, TOKEN_REFRESH_INTERVAL);
+
+    return () => clearInterval(interval);
   });
 </script>
 


### PR DESCRIPTION
<!-- IMPORTANT: Please make sure you've pre-commit installed and have run it on commit. -->
<!-- Also follow contribution guidelines: https://github.com/quibble-dev/Quibble/blob/main/CONTRIBUTING.md -->

## Description

Sets an interval to run every 14.5 mins (-5 access token lifespan), to ensure token gets refreshed even when user stays long without doing any activities (afk).

Fixes #234 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
