### PR TITLE
feat: IMAGE type on post creation

### DIFF
--- a/frontend/src/lib/pages/settings/profile/banner-setting.svelte
+++ b/frontend/src/lib/pages/settings/profile/banner-setting.svelte
@@ -51,7 +51,7 @@
     $errors.banner
       ? 'outline-error text-error'
       : 'outline-base-content/25 hover:outline-base-content/50',
-    'rounded-box relative flex h-24 w-full cursor-pointer flex-col items-center justify-center gap-1 bg-cover bg-center bg-no-repeat outline-2 -outline-offset-2 transition-[outline] outline-dashed'
+    'rounded-box relative flex h-24 w-full cursor-pointer flex-col items-center justify-center gap-1 bg-cover bg-center bg-no-repeat outline-2 -outline-offset-2 transition-[outline] duration-300 outline-dashed'
   )}
   style="background-image: url({banner_data_url || page.data.profile.banner});"
   ondrop={handle_drop}

--- a/frontend/src/lib/schemas/post-submit.ts
+++ b/frontend/src/lib/schemas/post-submit.ts
@@ -1,7 +1,32 @@
 import { z } from 'zod';
 
-export const PostSubmitSchema = z.object({
-  community: z.number().min(1, 'Please select a community.'),
-  title: z.string().min(1, 'Title cannot be empty.').max(300, 'Title is too long.'),
-  content: z.string()
+const BasePostSubmitSchema = z.object({
+  community: z.coerce
+    .number({ invalid_type_error: 'Please select a community.' })
+    .min(1, 'Community must be selected.'),
+  title: z
+    .string({ required_error: 'Please fill out this field.' })
+    .min(1, 'Title cannot be empty.')
+    .max(300),
+  type: z.enum(['TEXT', 'IMAGE'])
 });
+
+const TextPostSubmitSchema = BasePostSubmitSchema.extend({
+  type: z.literal('TEXT'),
+  content: z
+    .string({ required_error: 'Please fill out this field.' })
+    .min(1, 'Content cannot be empty.')
+});
+
+const ImagePostSubmitSchema = BasePostSubmitSchema.extend({
+  type: z.literal('IMAGE'),
+  cover: z
+    .instanceof(File)
+    .refine((f) => f.size < 5_000_000, 'Max 5 MB upload size.')
+    .refine((f) => f.type.startsWith('image/'), 'Only image files are supported now.')
+});
+
+export const PostSubmitSchema = z.discriminatedUnion('type', [
+  TextPostSubmitSchema,
+  ImagePostSubmitSchema
+]);

--- a/frontend/src/routes/(app)/submit/+page.server.ts
+++ b/frontend/src/routes/(app)/submit/+page.server.ts
@@ -1,4 +1,5 @@
 import api from '$lib/api';
+import { create_form_data, type FormDataObject } from '$lib/functions/form';
 import { PostSubmitSchema } from '$lib/schemas/post-submit';
 import type { PageServerLoad } from '../$types';
 import { fail, redirect, type Actions } from '@sveltejs/kit';
@@ -14,6 +15,7 @@ export const load: PageServerLoad = async () => {
 export const actions: Actions = {
   default: async ({ request, cookies }) => {
     const form = await superValidate(request, zod(PostSubmitSchema));
+    console.log(form);
 
     if (!form.valid) {
       return fail(400, { form });
@@ -21,9 +23,13 @@ export const actions: Actions = {
 
     const { data, response } = await api.POST('/posts/', {
       headers: { Cookie: request.headers.get('Cookie') },
+      // @ts-expect-error: needs cover field in File type
       body: {
         ...form.data,
         poster: Number(cookies.get('profile-id'))
+      },
+      bodySerializer(body) {
+        return create_form_data(body as unknown as FormDataObject);
       }
     });
 


### PR DESCRIPTION
<!-- IMPORTANT: Please make sure you've pre-commit installed and have run it on commit. -->
<!-- Also follow contribution guidelines: https://github.com/quibble-dev/Quibble/blob/main/CONTRIBUTING.md -->

## Description

Include `IMAGE` type on post creation (currently only `image/**` support, no vid format).
With dynamic zod schema validation.

Fixes #310 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
